### PR TITLE
Disable login redirect to dbbrowser.aspx forbidding redirects altogether

### DIFF
--- a/Sitecore.Linqpad/Server/CookieAwareWebClient.cs
+++ b/Sitecore.Linqpad/Server/CookieAwareWebClient.cs
@@ -21,6 +21,7 @@ namespace Sitecore.Linqpad.Server
             if (request2 != null)
             {
                 request2.CookieContainer = this.Cookies;
+                request2.AllowAutoRedirect = false;
             }
             webRequest.Timeout = 300000;
             return webRequest;


### PR DESCRIPTION
When performing login the WebClient instance was getting a http response with status 302 from the login.aspx page targeting the dbbrowser.aspx page, WebClient was then performing the redirect. The problem in my sitecore 8.2 rev 161221 (teste on 8.1 rev 160519 as well) instance is that for some reason the request to dbbrowser.aspx gets stuck somewhere and it never loads the page timing out the request on the driver. I tested access do the dbbrowser.aspx using the browser, the result is the same.

This redirect is really unnecessary since all the driver wants when logging in is the .ASPXAUTH cookie for future requests. What I did here was just disable redirects for the WebClient instance for all requests and now I am able to run the driver on LinqPad 5 and Sitecore 8.2 Update 2 (161221).